### PR TITLE
Fix failing nextPreviousPageTest for limited page count

### DIFF
--- a/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/production/ebookData.json
+++ b/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/production/ebookData.json
@@ -3,8 +3,8 @@
     "ebook": {
       "user": {
 
-        "pageNumber14":"14-15 / 106",
-        "pageNumber12":"12-13 / 106",
+        "pageNumber14":"14-15 / 104",
+        "pageNumber12":"12-13 / 104",
 
         "player": {
            "exitActivity" : "Exit activity",


### PR DESCRIPTION
### Summary

This PR fixes an issue in the QA automation test `nextPreviousPageTest`, where the test was attempting to navigate to page 106 even though the book only contains 104 pages. This caused the test to fail due to exceeding the valid page range.
