### PR TITLE
feat: replicate manageReports test suite to qa and rel environments

### DIFF
--- a/.agent/skills/c1-environment-test-replicator/SKILL.md
+++ b/.agent/skills/c1-environment-test-replicator/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: c1-environment-test-replicator
+description: >
+  Replicates a test suite from one environment to another (or multiple environments) in the C1 test automation framework.
+  Use this skill whenever the user wants to copy or replicate a test to another environment, port a test from thor to qa,
+  stage, or production, run tests after replication, fix environment-specific failures, update selectors or test data
+  for a new environment. Trigger on any mention of: replicate test, port test, copy test to environment,
+  test not working in qa, test not working in stage, run test in new environment, fix test for environment.
+---
+
+# C1 Environment Test Replicator Skill
+
+You are replicating a test suite across environments in the Cambridge One (C1) WebDriverIO test automation framework.
+Follow all steps below exactly.
+
+---
+
+## STEP 1 — Understand What Needs Replicating
+
+Before doing anything, confirm with the user:
+
+1. **Source environment** — where the working test lives (e.g. `thor`)
+2. **Test name** — the base name without environment suffix (e.g. `manageReportsTest`)
+3. **Target environment(s)** — where to replicate to (e.g. `qa`, `stage`, `production`)
+
+Source files you will be working with:
+- `testExecutionFiles/ExperienceApp/<sourceEnv>/<testName>.json`
+- `testcaseData/ExperienceApp/<sourceEnv>/<testName>_data.json`
+- `package.json` (to read the source NPM script)
+- `env.json` (to get URL mappings per environment)
+
+---
+
+## STEP 2 — Replicate Files to Target Environment
+
+### 2a. Copy Execution File
+Copy `testExecutionFiles/ExperienceApp/<sourceEnv>/<testName>.json`
+to `testExecutionFiles/ExperienceApp/<targetEnv>/<testName>.json`
+
+No changes needed to the execution file structure — TC IDs, test file paths, and suite structure stay identical.
+
+### 2b. Copy Test Data File
+Copy `testcaseData/ExperienceApp/<sourceEnv>/<testName>_data.json`
+to `testcaseData/ExperienceApp/<targetEnv>/<testName>_data.json`
+
+Then replace all environment-specific URLs:
+- Read `env.json` to get `appUrl` for source and target environments
+- Replace every occurrence of the source `appUrl` with the target `appUrl`
+- Example: `https://thor.cambridge.edu` → `https://qa.cambridge.edu`
+
+### 2c. Add NPM Script to package.json
+Read the source NPM script from `package.json`:
+```
+"<testName>_<sourceEnv>": "npx wdio --appType=... --testEnv=<sourceEnv> ..."
+```
+
+Add a new entry replacing source env with target env:
+```
+"<testName>_<targetEnv>": "npx wdio --appType=... --testEnv=<targetEnv> --testExecFile=testExecutionFiles/ExperienceApp/<targetEnv>/<testName>.json ..."
+```
+
+Show a preview of all files to be created/modified and ask: **"Ready to create these files? (yes/no)"**
+
+---
+
+## STEP 3 — Run the Test in Target Environment
+
+After files are created, run:
+```
+npm run <testName>_<targetEnv>
+```
+
+Capture the output and identify:
+- Which TCs passed ✓
+- Which TCs failed ✗ and why
+
+---
+
+## STEP 4 — Analyse Failures
+
+For each failing TC, classify the failure type:
+
+### Failure Type 1: Selector Not Found
+**Symptoms:** `Element not found`, `No such element`, selector error
+**Root cause:** DOM structure is different in target environment
+**Fix:** Update the selector value in `testResources/selectors/ExperienceApp/C1Selectors.json`
+- Find the current selector path (e.g. `css.ComproC1.manageReports.reportTable`)
+- Inspect the target environment DOM for the correct selector
+- Propose new value with confidence score (50–100%)
+
+### Failure Type 2: Assertion Mismatch
+**Symptoms:** `AssertionError: expected X to equal Y`, wrong text/value on page
+**Root cause:** Test data has wrong expected value for this environment
+**Fix:** Update the value in `testcaseData/ExperienceApp/<targetEnv>/<testName>_data.json`
+- Find the exact JSON path of the wrong value
+- Propose correct value based on what the page actually shows
+
+### Failure Type 3: Timeout
+**Symptoms:** `TimeoutError: element not displayed after Nms`
+**Root cause:** Page loads slower in target env, or feature not available
+**Fix:** Investigate — may need wait time increase or TC skip for this environment
+
+### Failure Type 4: Navigation Error
+**Symptoms:** `404 Not Found`, `Could not navigate to URL`
+**Root cause:** Wrong URL in `env.json` or feature path changed
+**Fix:** Update `appUrl` in `env.json` for the target environment
+
+---
+
+## STEP 5 — Propose Fixes
+
+For each failure, present fixes clearly:
+
+```
+ISSUE #1 — Selector Not Found (Confidence: 95%)
+  TC: TST_MRPT_TC_1
+  Selector path: css.ComproC1.manageReports.reportTable
+  Current value: [role="grid"].reports-table
+  Proposed value: [data-qid="report-grid-qa"]
+  File: testResources/selectors/ExperienceApp/C1Selectors.json
+  Impact: TST_MRPT_TC_1, TST_MRPT_TC_3
+
+ISSUE #2 — Assertion Mismatch (Confidence: 98%)
+  TC: TST_MRPT_TC_2
+  Data path: $.reports[0].name
+  Current value: "Q3 Report"
+  Proposed value: "Q3 2024 Report"
+  File: testcaseData/ExperienceApp/qa/manageReportsTest_data.json
+  Impact: TST_MRPT_TC_2
+```
+
+Ask: **"Apply these fixes? (yes / no / review each)"**
+
+**Confidence scoring:**
+- 90–100% → Very likely correct, auto-approve recommended
+- 70–89% → Likely correct, review before applying
+- 50–69% → Uncertain, manual investigation recommended
+- <50% → Do not auto-apply
+
+---
+
+## STEP 6 — Apply Fixes and Re-Validate
+
+After user approves:
+1. Apply all approved fixes to the relevant files
+2. Add a comment next to each fix: `// Updated for <targetEnv> environment — <reason>`
+3. Re-run: `npm run <testName>_<targetEnv>`
+4. Confirm all previously failing TCs now pass
+
+If tests still fail after fixes, repeat Steps 4–6 (maximum 3 iterations).
+
+---
+
+## STEP 7 — Generate Walkthrough
+
+At the end, produce a walkthrough entry:
+
+```markdown
+### <testName> replicated to <targetEnv> — <date>
+- **Type:** Created + Modified
+- **Layer:** Test Resources (Execution Files, Test Data, Selectors)
+- **Files created:**
+  - testExecutionFiles/ExperienceApp/<targetEnv>/<testName>.json
+  - testcaseData/ExperienceApp/<targetEnv>/<testName>_data.json
+- **Files modified:**
+  - C1Selectors.json (if selector fix applied)
+  - package.json (new NPM script added)
+- **Test results:** All TCs passing in <targetEnv> ✓
+- **Fixes applied:** <N> (list each fix with before/after)
+- **Architecture compliance:** No violations — protected files not touched
+```
+
+---
+
+## Safety Rules
+
+- **NEVER** modify protected files: `wdio.conf.js`, `env.conf.js`, `baseActionLibrary.js`, `baseAssertionLibrary.js`, `testrunner.js`, `specGenerator.js`, `launchUrl.js`
+- **NEVER** modify test case files (`.test.js`) or page object files (`.page.js`) to fix environment issues — fix selectors and data instead
+- **ALWAYS** show a preview before creating or modifying files
+- **ALWAYS** ask for approval before applying fixes
+- **ALWAYS** re-run tests after fixes to validate
+- **ALWAYS** generate a walkthrough at the end
+
+---
+
+## Quick Reference
+
+| What to replicate | Files to copy |
+|---|---|
+| Execution flow | `testExecutionFiles/ExperienceApp/<env>/<testName>.json` |
+| Test data | `testcaseData/ExperienceApp/<env>/<testName>_data.json` |
+| NPM script | Add entry to `package.json` |
+| Selector fix | `testResources/selectors/ExperienceApp/C1Selectors.json` |
+| URL mapping | Read from `env.json` |

--- a/testAutomation_v1.0/.architecture/walkthroughs/walkthrough_2026-05-26.md
+++ b/testAutomation_v1.0/.architecture/walkthroughs/walkthrough_2026-05-26.md
@@ -1,0 +1,74 @@
+# Session Walkthrough — 2026-05-26
+
+## Summary
+Replicated the `manageReportsTest` suite from the `thor` environment to `qa`. This involved creating the QA execution file, creating the QA test data file with the environment-specific class name, and registering the new NPM script in `package.json`.
+
+---
+
+## Changes Made
+
+### 1. testResources/testExecutionFiles/ExperienceApp/qa/manageReportsTest.json
+- **Type:** Created
+- **Layer:** Test Resources — Execution File
+- **What changed:** New execution file for the QA environment. Copied Suite1 structure from the thor counterpart (`testExecutionFiles/ExperienceApp/thor/manageReportsTest.json`). All `testData.dataFile` paths updated from `thor` to `qa` (two login data references and one manageReportsData reference).
+- **Why:** Environment replication — the test must reference QA-environment data files so the test runner resolves credentials and class names from the correct environment directory.
+- **Lines affected:** All — new file; key changes are `dataFile` paths on the `TST_LOGI_TC_1`, `TST_LOGI_TC_2`, and `TST_DASH_TC_11` Before steps.
+
+### 2. testResources/testcaseData/ExperienceApp/qa/manageReportsData.json
+- **Type:** Created
+- **Layer:** Test Resources — Test Data
+- **What changed:** New QA-environment test data file. Contains the class name used by `TST_DASH_TC_11` to click the correct class card on the dashboard. Value updated from thor's `"NLP Class"` to QA's `"Class 8 April"` as confirmed by the user.
+- **Why:** The class name differs between environments. Using the thor class name in QA would cause `TST_DASH_TC_11` (click class card) to fail with an element-not-found error.
+- **Lines affected:** All — new file. JSON path: `C1.manageReports.className = "Class 8 April"`.
+
+### 3. package.json
+- **Type:** Modified
+- **Layer:** Configuration
+- **What changed:** Added new NPM script `manageReportsTest_qa`. Script mirrors `manageReportsTest_thor` with `--testEnv=qa` substituted for `--testEnv=thor`.
+- **Why:** Required for running the QA test suite from the command line (`npm run manageReportsTest_qa`). Follows the `<feature>_<env>` naming convention per AGENTS.md.
+- **Lines affected:** New entry at end of scripts block.
+  - Added: `"manageReportsTest_qa": "npx wdio --appType=ExperienceApp --testEnv=qa --testExecFile='manageReportsTest.json' --browserCapability=desktop-chrome-1920"`
+- **Note on visual script:** Not added — both `TST_MRPT_TC_1` and `TST_MRPT_TC_2` have `"visualTest": false` in `C1TCRepository.json`, so no `visualAcceptance_manageReports_qa` script is required per Rule B of AGENTS.md.
+
+---
+
+## Architecture Decisions Triggered
+- **ADR-006** (Environment-Specific Data Separation): Followed — QA data lives in `testcaseData/ExperienceApp/qa/`, QA execution file lives in `testExecutionFiles/ExperienceApp/qa/`. No environment-specific values introduced into Page Objects or Test Cases.
+- **ADR-001** (JSON-Driven Test Execution): Followed — the execution file references existing TC IDs registered in `C1TCRepository.json`. No new TC functions were created.
+
+---
+
+## Protected Files Touched
+- `package.json` — new script entry added (`manageReportsTest_qa`). Confirmed by user before modification.
+
+---
+
+## Test Execution Status
+- The `manageReportsTest_qa` script was invoked during this session but could not complete in the automation sandbox (no Chrome browser available in the environment).
+- **Action required:** Run `npm run manageReportsTest_qa` from your local machine to validate `TST_MRPT_TC_1` and `TST_MRPT_TC_2` in the QA environment.
+- If failures occur, common failure types to check:
+  - **Selector mismatch** → update `testResources/selectors/ExperienceApp/C1Selectors.json` under `css.ComproC1.manageReports`
+  - **Class name mismatch** → update `className` in `testResources/testcaseData/ExperienceApp/qa/manageReportsData.json`
+  - **Login credential issue** → verify `testResources/testcaseData/ExperienceApp/qa/logindata.json` has a valid QA instructor account
+
+## Pending / Follow-up
+- ~~Run `npm run manageReportsTest_qa` locally and verify both TCs pass.~~ ✅ **Completed 2026-05-26** — Both TCs passed (see Test Execution Update below).
+- No further follow-up required for this suite.
+
+---
+
+## Test Execution Update — 2026-05-26
+
+### Summary
+Executed `npm run manageReportsTest_qa` on local machine. Both test cases passed in 29.8s.
+
+### Result
+| TC ID | Description | Result |
+|---|---|---|
+| TST_MRPT_TC_1 | Click Manage Reports from Actions dropdown | ✅ PASSED |
+| TST_MRPT_TC_2 | Verify Download button has correct button role for accessibility | ✅ PASSED |
+
+- **Suite:** Suite1 — Validation of Manage Reports Download Button Accessibility
+- **Browser:** Chrome 148.0.7778.168 on Windows
+- **Duration:** 29.8s
+- **No files were created or modified during this execution.**

--- a/testAutomation_v1.0/.architecture/walkthroughs/walkthrough_2026-05-27.md
+++ b/testAutomation_v1.0/.architecture/walkthroughs/walkthrough_2026-05-27.md
@@ -1,0 +1,77 @@
+# Session Walkthrough — 2026-05-27
+
+## Summary
+Replicated the `manageReportsTest` suite from the `thor` environment to `rel` (release). This involved creating the rel execution file, creating the rel test data file with the environment-specific class name, adding a dedicated instructor user entry to the rel login data, and registering the new NPM script in `package.json`.
+
+---
+
+## Changes Made
+
+### 1. testResources/testExecutionFiles/ExperienceApp/rel/manageReportsTest.json
+- **Type:** Created
+- **Layer:** Test Resources — Execution File
+- **What changed:** New execution file for the `rel` environment. Copied Suite1 structure from the thor counterpart (`testExecutionFiles/ExperienceApp/thor/manageReportsTest.json`). All `testData.dataFile` paths updated from `thor` to `rel`. Login steps (`TST_LOGI_TC_1`, `TST_LOGI_TC_2`) reference `C1.login.user.manageReportsInstructor` instead of `successfulInstructorUser` — a dedicated user key added to avoid disrupting other rel tests that rely on `successfulInstructorUser`.
+- **Why:** Environment replication — the test must reference rel-environment data files so the test runner resolves credentials and class names from the correct environment directory.
+- **Lines affected:** All — new file. Key changes are `dataFile` paths on the `TST_LOGI_TC_1`, `TST_LOGI_TC_2`, and `TST_DASH_TC_11` Before steps, and `jsonPath` on both login steps.
+
+### 2. testResources/testcaseData/ExperienceApp/rel/manageReportsData.json
+- **Type:** Created
+- **Layer:** Test Resources — Test Data
+- **What changed:** New rel-environment test data file. Contains the class name used by `TST_DASH_TC_11` to click the correct class card on the dashboard.
+- **Why:** The class name differs between environments. Thor uses `"NLP Class"`, QA uses `"Class 8 April"`, and rel requires `"Release Class"` as confirmed by the user.
+- **Lines affected:** All — new file. JSON path: `C1.manageReports.className = "Release Class"`.
+
+### 3. testResources/testcaseData/ExperienceApp/rel/logindata.json
+- **Type:** Modified
+- **Layer:** Test Resources — Test Data
+- **What changed:** Added new user entry `manageReportsInstructor` at the end of the `C1.login.user` object (after `flipbookUser`).
+  ```json
+  "manageReportsInstructor": {
+    "email": "comprotestuser+relteacontext@gmail.com",
+    "password": "Compro11",
+    "role": "teacher",
+    "name": "relteacontext",
+    "class": [],
+    "info": {}
+  }
+  ```
+- **Why:** The user specified `comprotestuser+relteacontext@gmail.com` as the instructor for the rel manage reports test. This email did not exist in any data file. A dedicated key was created rather than overwriting `successfulInstructorUser` to avoid breaking other rel tests (`dashboardTest_Teacher.json`, etc.) that depend on that key.
+- **Lines affected:** Inserted after `flipbookUser` closing brace — approximately lines 288–297 (post-edit).
+
+### 4. package.json
+- **Type:** Modified
+- **Layer:** Configuration
+- **What changed:** Added new NPM script `manageReportsTest_rel` after `manageReportsTest_qa`.
+  - Added: `"manageReportsTest_rel": "npx wdio --appType=ExperienceApp --testEnv=rel --testExecFile='manageReportsTest.json' --browserCapability=desktop-chrome-1920"`
+- **Why:** Required for running the rel test suite from the command line. Follows the `<feature>_<env>` naming convention per AGENTS.md.
+- **Note on visual script:** Not added — both `TST_MRPT_TC_1` and `TST_MRPT_TC_2` have `"visualTest": false` in `C1TCRepository.json`, so no `visualAcceptance_manageReports_rel` script is required per AGENTS.md Rule B.
+
+---
+
+## Architecture Decisions Triggered
+- **ADR-006** (Environment-Specific Data Separation): Followed — rel data lives in `testcaseData/ExperienceApp/rel/`, rel execution file lives in `testExecutionFiles/ExperienceApp/rel/`. No environment-specific values introduced into Page Objects or Test Cases.
+- **ADR-001** (JSON-Driven Test Execution): Followed — the execution file references only existing TC IDs registered in `C1TCRepository.json`. No new TC functions were created.
+
+---
+
+## Protected Files Touched
+- `package.json` — new script entry added (`manageReportsTest_rel`). Confirmed by user before modification.
+
+---
+
+## Test Execution Results
+`npm run manageReportsTest_rel` executed immediately after replication.
+
+| TC ID | Description | Result |
+|---|---|---|
+| TST_MRPT_TC_1 | Click Manage Reports from Actions dropdown | ✅ PASSED |
+| TST_MRPT_TC_2 | Verify Download button has correct button role for accessibility | ✅ PASSED |
+
+- **Browser:** Chrome 148.0.7778.168 on Windows
+- **Duration:** 38.4s
+- **Fixes required:** None — both TCs passed on first run.
+
+---
+
+## Pending / Follow-up
+None — replication is complete and validated.

--- a/testAutomation_v1.0/package.json
+++ b/testAutomation_v1.0/package.json
@@ -102,7 +102,9 @@
     "drawingFeatureTest_qa": "npx wdio --appType=ExperienceApp --testEnv=qa --testExecFile='drawingTool.json' --browserCapability=desktop-chrome-1920",
     "eBookHotLinkTest_qa": "npx wdio --appType=ExperienceApp --testEnv=qa --testExecFile='player.json' --browserCapability=desktop-chrome-1920",
     "loginFeatureTest_LTmobile": "npx wdio  --appType=ExperienceApp --testEnv=production --testExecFile='loginTest.json' --browserCapability=lambdatest-android-samsungS24",
-    "manageReportsTest_thor": "npx wdio --appType=ExperienceApp --testEnv=thor --testExecFile='manageReportsTest.json' --browserCapability=desktop-chrome-1920"
+    "manageReportsTest_thor": "npx wdio --appType=ExperienceApp --testEnv=thor --testExecFile='manageReportsTest.json' --browserCapability=desktop-chrome-1920",
+    "manageReportsTest_qa": "npx wdio --appType=ExperienceApp --testEnv=qa --testExecFile='manageReportsTest.json' --browserCapability=desktop-chrome-1920",
+    "manageReportsTest_rel": "npx wdio --appType=ExperienceApp --testEnv=rel --testExecFile='manageReportsTest.json' --browserCapability=desktop-chrome-1920"
   },
   "keywords": [],
   "author": "",

--- a/testAutomation_v1.0/testResources/testExecutionFiles/ExperienceApp/qa/manageReportsTest.json
+++ b/testAutomation_v1.0/testResources/testExecutionFiles/ExperienceApp/qa/manageReportsTest.json
@@ -1,0 +1,84 @@
+{
+  "Suite1": {
+    "Name": "Validation of Manage Reports Download Button Accessibility",
+    "TestCaseRepo": [
+      "./testResources/testcaseRepository/ExperienceApp/C1TCRepository.json"
+    ],
+    "Before": [
+      {
+        "id": "launchUrl",
+        "description": "",
+        "testFile": "./core/runner/launchUrl.js",
+        "testData": []
+      },
+      {
+        "id": "TST_LAND_TC_3",
+        "description": "Click Login button on Landing page",
+        "testFile": "./test/ExperienceApp/landing.test.js",
+        "testData": []
+      },
+      {
+        "id": "TST_LOGI_TC_1",
+        "description": "Enter Instructor User Name",
+        "testFile": "./test/ExperienceApp/login.test.js",
+        "testData": [
+          {
+            "dataFile": "./testResources/testcaseData/ExperienceApp/qa/logindata.json",
+            "jsonPath": "C1.login.user.successfulInstructorUser"
+          }
+        ]
+      },
+      {
+        "id": "TST_LOGI_TC_2",
+        "description": "Enter Instructor Password",
+        "testFile": "./test/ExperienceApp/login.test.js",
+        "testData": [
+          {
+            "dataFile": "./testResources/testcaseData/ExperienceApp/qa/logindata.json",
+            "jsonPath": "C1.login.user.successfulInstructorUser"
+          }
+        ]
+      },
+      {
+        "id": "TST_LOGI_TC_5",
+        "description": "Click Login button",
+        "testFile": "./test/ExperienceApp/login.test.js",
+        "testData": []
+      },
+      {
+        "id": "TST_DASH_TC_11",
+        "description": "Click on Class 8 April Class card",
+        "testFile": "./test/ExperienceApp/dashboard.test.js",
+        "testData": [
+          {
+            "dataFile": "./testResources/testcaseData/ExperienceApp/qa/manageReportsData.json",
+            "jsonPath": "C1.manageReports.className"
+          }
+        ]
+      },
+      {
+        "id": "TST_ACTI_TC_1",
+        "description": "Click Actions dropdown button",
+        "testFile": "./test/ExperienceApp/activeClass.test.js",
+        "testData": []
+      }
+    ],
+    "BeforeEach": [],
+    "Test": [
+      {
+        "id": "TST_MRPT_TC_1",
+        "description": "Click Manage Reports from Actions dropdown",
+        "testFile": "./test/ExperienceApp/manageReports.test.js",
+        "testData": []
+      },
+      {
+        "id": "TST_MRPT_TC_2",
+        "description": "Verify Download button has correct button role for accessibility",
+        "testFile": "./test/ExperienceApp/manageReports.test.js",
+        "testData": []
+      }
+    ],
+    "AfterEach": [],
+    "After": []
+  }
+}

--- a/testAutomation_v1.0/testResources/testExecutionFiles/ExperienceApp/rel/manageReportsTest.json
+++ b/testAutomation_v1.0/testResources/testExecutionFiles/ExperienceApp/rel/manageReportsTest.json
@@ -1,0 +1,84 @@
+{
+  "Suite1": {
+    "Name": "Validation of Manage Reports Download Button Accessibility",
+    "TestCaseRepo": [
+      "./testResources/testcaseRepository/ExperienceApp/C1TCRepository.json"
+    ],
+    "Before": [
+      {
+        "id": "launchUrl",
+        "description": "",
+        "testFile": "./core/runner/launchUrl.js",
+        "testData": []
+      },
+      {
+        "id": "TST_LAND_TC_3",
+        "description": "Click Login button on Landing page",
+        "testFile": "./test/ExperienceApp/landing.test.js",
+        "testData": []
+      },
+      {
+        "id": "TST_LOGI_TC_1",
+        "description": "Enter Instructor User Name",
+        "testFile": "./test/ExperienceApp/login.test.js",
+        "testData": [
+          {
+            "dataFile": "./testResources/testcaseData/ExperienceApp/rel/logindata.json",
+            "jsonPath": "C1.login.user.manageReportsInstructor"
+          }
+        ]
+      },
+      {
+        "id": "TST_LOGI_TC_2",
+        "description": "Enter Instructor Password",
+        "testFile": "./test/ExperienceApp/login.test.js",
+        "testData": [
+          {
+            "dataFile": "./testResources/testcaseData/ExperienceApp/rel/logindata.json",
+            "jsonPath": "C1.login.user.manageReportsInstructor"
+          }
+        ]
+      },
+      {
+        "id": "TST_LOGI_TC_5",
+        "description": "Click Login button",
+        "testFile": "./test/ExperienceApp/login.test.js",
+        "testData": []
+      },
+      {
+        "id": "TST_DASH_TC_11",
+        "description": "Click on Release Class card",
+        "testFile": "./test/ExperienceApp/dashboard.test.js",
+        "testData": [
+          {
+            "dataFile": "./testResources/testcaseData/ExperienceApp/rel/manageReportsData.json",
+            "jsonPath": "C1.manageReports.className"
+          }
+        ]
+      },
+      {
+        "id": "TST_ACTI_TC_1",
+        "description": "Click Actions dropdown button",
+        "testFile": "./test/ExperienceApp/activeClass.test.js",
+        "testData": []
+      }
+    ],
+    "BeforeEach": [],
+    "Test": [
+      {
+        "id": "TST_MRPT_TC_1",
+        "description": "Click Manage Reports from Actions dropdown",
+        "testFile": "./test/ExperienceApp/manageReports.test.js",
+        "testData": []
+      },
+      {
+        "id": "TST_MRPT_TC_2",
+        "description": "Verify Download button has correct button role for accessibility",
+        "testFile": "./test/ExperienceApp/manageReports.test.js",
+        "testData": []
+      }
+    ],
+    "AfterEach": [],
+    "After": []
+  }
+}

--- a/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/qa/logindata.json
+++ b/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/qa/logindata.json
@@ -85,7 +85,7 @@
             "info": {}
           },
           "successfulInstructorUser": {
-            "email": "thorteacherda@mailsac.com",
+            "email": "qateacherda@mailsac.com",
             "password": "Compro11",
             "role": "teacher",
             "name": "difusionqa teach46",

--- a/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/qa/manageReportsData.json
+++ b/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/qa/manageReportsData.json
@@ -1,0 +1,7 @@
+{
+  "C1": {
+    "manageReports": {
+      "className": "Class 8 April"
+    }
+  }
+}

--- a/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/rel/logindata.json
+++ b/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/rel/logindata.json
@@ -284,6 +284,14 @@
             "name": "flipbook automation",
             "class": [],
             "info": {}
+          },
+          "manageReportsInstructor": {
+            "email": "comprotestuser+relteacontext@gmail.com",
+            "password": "Compro11",
+            "role": "teacher",
+            "name": "relteacontext",
+            "class": [],
+            "info": {}
           }
         }
       },

--- a/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/rel/manageReportsData.json
+++ b/testAutomation_v1.0/testResources/testcaseData/ExperienceApp/rel/manageReportsData.json
@@ -1,0 +1,7 @@
+{
+  "C1": {
+    "manageReports": {
+      "className": "Release Class"
+    }
+  }
+}


### PR DESCRIPTION
- Added execution files for qa and rel (manageReportsTest.json) with correct env-specific dataFile paths
- Added test data files for qa (className: "Class 8 April") and rel (className: "Release Class")
- Added manageReportsInstructor user to rel/logindata.json for comprotestuser+relteacontext@gmail.com
- Fixed successfulInstructorUser email in qa/logindata.json to qateacherda@mailsac.com
- Added manageReportsTest_qa and manageReportsTest_rel npm scripts
- Validated: TST_MRPT_TC_1 and TST_MRPT_TC_2 pass in both environments